### PR TITLE
skip using MicronautSecurityUserArgumentBinder when micronaut.security.enabled is set to false

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/groovy/micronaut-compatibility.gradle
+++ b/buildSrc/src/main/groovy/micronaut-compatibility.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/guide/guide.gradle
+++ b/docs/guide/guide.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/guide/src/docs/asciidoc/usage.adoc
+++ b/docs/guide/src/docs/asciidoc/usage.adoc
@@ -156,7 +156,7 @@ You can specify from which address the users can access the console
 .Address Filter Configuration
 ----
 console:
-include::{root-dir}/examples/micronaut-console-example-application/src/main/resources/application.yml[tags=address]
+include::{root-dir}/examples/micronaut-console-example-application/src/main/resources/application-secured.yml[tags=address]
 ----
 
 WARNING: The addresses must start with a forward slash `/`.
@@ -171,7 +171,7 @@ You can specify which users can access the console
 .User FilterConfiguration
 ----
 console:
-include::{root-dir}/examples/micronaut-console-example-application/src/main/resources/application.yml[tags=users]
+include::{root-dir}/examples/micronaut-console-example-application/src/main/resources/application-secured.yml[tags=users]
 ----
 
 You must use Micronaut Security Integration or define your own implementation of `TypedRequestArgumentBinder<User>` to
@@ -190,7 +190,7 @@ Micronaut Console integrates well with the Micronaut Security library.
 [source]
 .Micronaut Security Configuration
 ----
-include::{root-dir}/examples/micronaut-console-example-application/src/main/resources/application.yml[tags=micronaut-security]
+include::{root-dir}/examples/micronaut-console-example-application/src/main/resources/application-secured.yml[tags=micronaut-security]
 ----
 <1> Enable Micronaut Security
 <2> Enable login endpoint

--- a/examples/micronaut-console-example-application/gradle.properties
+++ b/examples/micronaut-console-example-application/gradle.properties
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright 2020-2021 Agorapulse.
+# Copyright 2020-2022 Agorapulse.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/micronaut-console-example-application/micronaut-console-example-application.gradle
+++ b/examples/micronaut-console-example-application/micronaut-console-example-application.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/micronaut-console-example-application/src/main/java/micronaut/console/example/Application.java
+++ b/examples/micronaut-console-example-application/src/main/java/micronaut/console/example/Application.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/micronaut-console-example-application/src/main/java/micronaut/console/example/AuthenticationProviderUserPassword.java
+++ b/examples/micronaut-console-example-application/src/main/java/micronaut/console/example/AuthenticationProviderUserPassword.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/micronaut-console-example-application/src/main/java/micronaut/console/example/SimpleAuthentication.java
+++ b/examples/micronaut-console-example-application/src/main/java/micronaut/console/example/SimpleAuthentication.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/micronaut-console-example-application/src/main/java/micronaut/console/example/SimpleAuthenticationResponse.java
+++ b/examples/micronaut-console-example-application/src/main/java/micronaut/console/example/SimpleAuthenticationResponse.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/micronaut-console-example-application/src/main/resources/application-secured.yml
+++ b/examples/micronaut-console-example-application/src/main/resources/application-secured.yml
@@ -1,0 +1,35 @@
+# tag::micronaut-security[]
+micronaut:
+  security:
+    enabled: true                                                                       # <1>
+    endpoints:
+      login:
+        enabled: true                                                                   # <2>
+    token:
+      jwt:
+        enabled: true                                                                   # <3>
+        signatures:
+          secret:
+            generator:
+              secret: pleaseChangeThisSecretForANewOne                                  # <4>
+    intercept-url-map:
+      - pattern: /console/**                                                            # <5>
+        http-method: GET
+        access:
+          - isAnonymous()
+      - pattern: /console/**                                                            # <6>
+        http-method: POST
+        access:
+          - isAuthenticated()
+# end::micronaut-security[]
+console:
+  # tag::users[]
+  users:
+    - sherlock
+  # end::users[]
+  # tag::address[]
+  addresses:
+    - /127.0.0.1
+    - /0:0:0:0:0:0:0:1
+  # end::address[]
+  until: 2030-11-12T10:28:00Z

--- a/examples/micronaut-console-example-application/src/main/resources/application.yml
+++ b/examples/micronaut-console-example-application/src/main/resources/application.yml
@@ -1,39 +1,6 @@
 micronaut:
-  application:
-    name: micronaut-console-example
----
-# tag::micronaut-security[]
-micronaut:
   security:
-    enabled: true                                                                       # <1>
-    endpoints:
-      login:
-        enabled: true                                                                   # <2>
-    token:
-      jwt:
-        enabled: true                                                                   # <3>
-        signatures:
-          secret:
-            generator:
-              secret: pleaseChangeThisSecretForANewOne                                  # <4>
-    intercept-url-map:
-      - pattern: /console/**                                                            # <5>
-        http-method: GET
-        access:
-          - isAnonymous()
-      - pattern: /console/**                                                            # <6>
-        http-method: POST
-        access:
-          - isAuthenticated()
-# end::micronaut-security[]
+    enabled: false
+
 console:
-  # tag::users[]
-  users:
-    - sherlock
-  # end::users[]
-  # tag::address[]
-  addresses:
-    - /127.0.0.1
-    - /0:0:0:0:0:0:0:1
-  # end::address[]
-  until: 2030-11-12T10:28:00Z
+  enabled: true

--- a/examples/micronaut-console-example-application/src/main/resources/logback.xml
+++ b/examples/micronaut-console-example-application/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
 
     SPDX-License-Identifier: Apache-2.0
 
-    Copyright 2020-2021 Agorapulse.
+    Copyright 2020-2022 Agorapulse.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/micronaut-console-example-application/src/test/groovy/micronaut/console/example/MicronautSecurityDisabledIntegrationSpec.groovy
+++ b/examples/micronaut-console-example-application/src/test/groovy/micronaut/console/example/MicronautSecurityDisabledIntegrationSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/micronaut-console-example-application/src/test/groovy/micronaut/console/example/MicronautSecurityIntegrationSpec.groovy
+++ b/examples/micronaut-console-example-application/src/test/groovy/micronaut/console/example/MicronautSecurityIntegrationSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/micronaut-console-example-application/src/test/resources/execute.sh
+++ b/examples/micronaut-console-example-application/src/test/resources/execute.sh
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright 2020-2021 Agorapulse.
+# Copyright 2020-2022 Agorapulse.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/micronaut-console-example-function/micronaut-console-example-function.gradle
+++ b/examples/micronaut-console-example-function/micronaut-console-example-function.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,26 @@
  * limitations under the License.
  */
 // tag::import-runtime[]
+
 import com.amazonaws.services.lambda.model.InvocationType
 import com.amazonaws.services.lambda.model.Runtime
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService
+
 // end::import-runtime[]
 // tag::import-sts[]
-import com.amazonaws.services.securitytoken.AWSSecurityTokenService
+
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient
 import com.amazonaws.services.securitytoken.model.GetCallerIdentityRequest
 import com.amazonaws.services.securitytoken.model.GetCallerIdentityResult
+import groovy.json.JsonOutput
+
 // end::import-sts[]
 // tag::import[]
-import groovy.json.JsonOutput
+
 import groovy.json.JsonSlurper
 import jp.classmethod.aws.gradle.lambda.AWSLambdaInvokeTask
 import jp.classmethod.aws.gradle.lambda.AWSLambdaMigrateFunctionTask
+
 // end::import[]
 
 /*

--- a/examples/micronaut-console-example-function/micronaut-console-example-function.gradle
+++ b/examples/micronaut-console-example-function/micronaut-console-example-function.gradle
@@ -16,22 +16,17 @@
  * limitations under the License.
  */
 // tag::import-runtime[]
-
 import com.amazonaws.services.lambda.model.InvocationType
 import com.amazonaws.services.lambda.model.Runtime
-import com.amazonaws.services.securitytoken.AWSSecurityTokenService
-
 // end::import-runtime[]
 // tag::import-sts[]
-
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient
 import com.amazonaws.services.securitytoken.model.GetCallerIdentityRequest
 import com.amazonaws.services.securitytoken.model.GetCallerIdentityResult
-import groovy.json.JsonOutput
-
 // end::import-sts[]
 // tag::import[]
-
+import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
 import jp.classmethod.aws.gradle.lambda.AWSLambdaInvokeTask
 import jp.classmethod.aws.gradle.lambda.AWSLambdaMigrateFunctionTask

--- a/examples/micronaut-console-example-function/src/main/resources/logback.xml
+++ b/examples/micronaut-console-example-function/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
 
     SPDX-License-Identifier: Apache-2.0
 
-    Copyright 2020-2021 Agorapulse.
+    Copyright 2020-2022 Agorapulse.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/micronaut-console-example-kotlin/micronaut-console-example-kotlin.gradle
+++ b/examples/micronaut-console-example-kotlin/micronaut-console-example-kotlin.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/micronaut-console-example-kotlin/src/main/kotlin/micronaut/console/example/kotlin/Application.kt
+++ b/examples/micronaut-console-example-kotlin/src/main/kotlin/micronaut/console/example/kotlin/Application.kt
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/micronaut-console-example-kotlin/src/main/resources/logback.xml
+++ b/examples/micronaut-console-example-kotlin/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
 
     SPDX-License-Identifier: Apache-2.0
 
-    Copyright 2020-2021 Agorapulse.
+    Copyright 2020-2022 Agorapulse.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright 2020-2021 Agorapulse.
+# Copyright 2020-2022 Agorapulse.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/micronaut-console.gradle
+++ b/libs/micronaut-console/micronaut-console.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 dependencies {
     annotationProcessor platform("io.micronaut:micronaut-bom:$micronautVersion")
     implementation platform("io.micronaut:micronaut-bom:$micronautVersion")

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/AuditService.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/AuditService.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/BindingProvider.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/BindingProvider.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ConsoleConfiguration.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ConsoleConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ConsoleEngine.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ConsoleEngine.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ConsoleEngineFactory.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ConsoleEngineFactory.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ConsoleException.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ConsoleException.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ConsoleSecurityException.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ConsoleSecurityException.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ConsoleService.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ConsoleService.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/DefaultAuditService.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/DefaultAuditService.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/DefaultBindingProvider.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/DefaultBindingProvider.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/DefaultConsoleEngineFactory.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/DefaultConsoleEngineFactory.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/DefaultConsoleService.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/DefaultConsoleService.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,10 @@ package com.agorapulse.micronaut.console;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.inject.Singleton;
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 @Singleton
 public class DefaultConsoleService implements ConsoleService {

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ExecutionResult.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ExecutionResult.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/Script.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/Script.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/SecurityAdvisor.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/SecurityAdvisor.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/User.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/User.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/advisors/AddressAdvisor.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/advisors/AddressAdvisor.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/advisors/CloudAdvisor.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/advisors/CloudAdvisor.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/advisors/UntilAdvisor.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/advisors/UntilAdvisor.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/advisors/UsersAdvisor.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/advisors/UsersAdvisor.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/function/AuthConsoleHandler.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/function/AuthConsoleHandler.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/function/AuthorizedScript.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/function/AuthorizedScript.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/function/ConsoleHandler.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/function/ConsoleHandler.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,10 @@
  */
 package com.agorapulse.micronaut.console.function;
 
-import com.agorapulse.micronaut.console.*;
+import com.agorapulse.micronaut.console.ConsoleConfiguration;
+import com.agorapulse.micronaut.console.ConsoleService;
+import com.agorapulse.micronaut.console.Script;
+import com.agorapulse.micronaut.console.User;
 import com.agorapulse.micronaut.console.util.ExceptionSanitizer;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.function.FunctionBean;

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/groovy/CompilerConfigurationCustomizer.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/groovy/CompilerConfigurationCustomizer.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/groovy/DsldGenerator.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/groovy/DsldGenerator.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/groovy/GdslGenerator.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/groovy/GdslGenerator.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/groovy/GroovyConsoleEngine.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/groovy/GroovyConsoleEngine.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/AnonymousUserArgumentBinder.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/AnonymousUserArgumentBinder.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/ConsoleController.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/ConsoleController.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,10 @@
 package com.agorapulse.micronaut.console.http;
 
 import com.agorapulse.micronaut.console.ConsoleException;
+import com.agorapulse.micronaut.console.ConsoleSecurityException;
 import com.agorapulse.micronaut.console.ConsoleService;
 import com.agorapulse.micronaut.console.ExecutionResult;
 import com.agorapulse.micronaut.console.Script;
-import com.agorapulse.micronaut.console.ConsoleSecurityException;
 import com.agorapulse.micronaut.console.User;
 import com.agorapulse.micronaut.console.ide.DslGenerator;
 import com.agorapulse.micronaut.console.util.ExceptionSanitizer;

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/ConsoleHeadersFilter.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/ConsoleHeadersFilter.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/MicronautSecurityUserArgumentBinder.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/MicronautSecurityUserArgumentBinder.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/MicronautSecurityUserArgumentBinder.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/MicronautSecurityUserArgumentBinder.java
@@ -32,7 +32,7 @@ import java.util.Optional;
 
 @Singleton
 @Replaces(AnonymousUserArgumentBinder.class)
-@Requires(property = "micronaut.security.enabled")
+@Requires(property = "micronaut.security.enabled", value = "true")
 public class MicronautSecurityUserArgumentBinder implements TypedRequestArgumentBinder<User> {
 
     @Override

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/RequestBindingProvider.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/RequestBindingProvider.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/RequestHolder.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/RequestHolder.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/ScriptJsonError.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/ScriptJsonError.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ide/DslGenerator.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ide/DslGenerator.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ide/TextGenerator.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ide/TextGenerator.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/jsr223/JavaScriptingConsoleEngine.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/jsr223/JavaScriptingConsoleEngine.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/jsr223/JavaScriptingConsoleEngineFactory.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/jsr223/JavaScriptingConsoleEngineFactory.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/util/ExceptionSanitizer.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/util/ExceptionSanitizer.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/BindingProviderSpec.groovy
+++ b/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/BindingProviderSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/UserTest.groovy
+++ b/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/UserTest.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/function/AuthConsoleHandlerSpec.groovy
+++ b/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/function/AuthConsoleHandlerSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/function/ConsoleHandlerSpec.groovy
+++ b/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/function/ConsoleHandlerSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/CloudSpec.groovy
+++ b/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/CloudSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/ConsoleControllerSpec.groovy
+++ b/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/ConsoleControllerSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/ConsoleHeadersFilterSpec.groovy
+++ b/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/ConsoleHeadersFilterSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/DefaultInterceptedInterface.groovy
+++ b/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/DefaultInterceptedInterface.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/DemoBindingProvider.groovy
+++ b/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/DemoBindingProvider.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/InterceptedInterface.groovy
+++ b/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/InterceptedInterface.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/MagicAdvisor.java
+++ b/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/MagicAdvisor.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/ParentClass.groovy
+++ b/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/ParentClass.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/SimpleUserBinder.java
+++ b/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/SimpleUserBinder.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/UntilSpec.groovy
+++ b/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/UntilSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/resources/com/agorapulse/micronaut/console/http/ConsoleControllerSpec/jsr223.js
+++ b/libs/micronaut-console/src/test/resources/com/agorapulse/micronaut/console/http/ConsoleControllerSpec/jsr223.js
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/resources/log4j2.xml
+++ b/libs/micronaut-console/src/test/resources/log4j2.xml
@@ -3,7 +3,7 @@
 
     SPDX-License-Identifier: Apache-2.0
 
-    Copyright 2020-2021 Agorapulse.
+    Copyright 2020-2022 Agorapulse.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2021 Agorapulse.
+ * Copyright 2020-2022 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
The value of `micronaut.security.enabled` is currently not taken into account, and thus disabling Micronaut Security breaks the console - it keeps trying bind `User` from the Micronaut Security that is not configured. This fix replaces the default argument binder with the Micronaut Security one only if `micronaut.security.enabled` is set to `true`.