### PR TITLE
Migrate to Maven Central publishing infrastructure

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -28,12 +28,11 @@ jobs:
       CI: true
       COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup Java 17
-      uses: actions/setup-java@v3
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
       with:
-        distribution: zulu
         java-version: 17
-    - uses: gradle/gradle-command-action@v2
-      with:
-        arguments: check coveralls --scan
+        distribution: zulu
+    - uses: gradle/actions/setup-gradle@v4
+    - run: ./gradlew check coveralls

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,33 +9,26 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GRADLE_OPTS: "-Xmx6g -Xms4g"
-      SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-      SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
       SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
       SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup Java 17
-        uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
-          distribution: zulu
           java-version: 17
-          cache: gradle
-      - name: Semantic Version
-        id: version
-        uses: ncipollo/semantic-version-action@v1
+          distribution: zulu
       - name: Decode PGP
         id: write_file
         uses: timheuer/base64-to-file@v1
         with:
           fileName: 'secret.pgp'
           encodedString: ${{ secrets.SIGNING_SECRET_KEY_BASE64 }}
+      - uses: gradle/actions/setup-gradle@v4
       - name: Release
         env:
           SIGNING_SECRET_KEY_PATH: ${{ steps.write_file.outputs.filePath }}
-        uses: gradle/gradle-command-action@v2
-        with:
-          arguments: gitPublishPush publishToSonatype closeAndReleaseSonatypeStagingRepository -Pversion=${{ steps.version.outputs.tag }} --scan -Dorg.ajoberstar.grgit.auth.username=${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
+        run: ./gradlew gitPublishPush publishAndReleaseToMavenCentral "-Pversion=${{ github.ref_name }}" -PmavenCentralUsername=${{ secrets.MAVEN_CENTRAL_USERNAME }} -PmavenCentralPassword=${{ secrets.MAVEN_CENTRAL_PASSWORD }} -Prelease=true "-Dorg.ajoberstar.grgit.auth.username=${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}" --stacktrace
   ping:
     name: Notify Upstream Repositories
     runs-on: ubuntu-latest
@@ -44,15 +37,13 @@ jobs:
       matrix:
         repository:
           - agorapulse/agorapulse-bom
+          - agorapulse/agorapulse-oss
     steps:
-      - uses: actions/checkout@v1
-      - name: Semantic Version
-        id: version
-        uses: ncipollo/semantic-version-action@v1
+      - uses: actions/checkout@v4
       - name: Dispatch to ${{ matrix.repository }}
         uses: peter-evans/repository-dispatch@v1
         with:
-          token: ${{ secrets.PERSONAL_TOKEN }}
+          token: ${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
           repository: ${{ matrix.repository }}
           event-type: ap-new-version-released-event
-          client-payload: '{ "group": "com.agorapulse", "module": "micronaut-console", "micronautCompatibility": [4], "version": "${{ steps.version.outputs.tag }}-micronaut-1.0", "property" : "micronaut.console.version", "github" : ${{ toJson(github) }} }'
+          client-payload: '{ "group": "com.agorapulse", "module": "micronaut-console", "micronautCompatibility": [4], "version": "${{ github.ref_name }}", "property" : "micronaut.console.version", "github" : ${{ toJson(github) }} }'

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build.gradle
+++ b/build.gradle
@@ -20,14 +20,13 @@ plugins {
     id 'org.kordamp.gradle.checkstyle'
     id 'org.kordamp.gradle.codenarc'
     id 'org.kordamp.gradle.coveralls'
-    id 'io.github.gradle-nexus.publish-plugin'
 }
 
-if (!project.hasProperty('ossrhUsername'))      ext.ossrhUsername       = System.getenv('SONATYPE_USERNAME') ?: '**UNDEFINED**'
-if (!project.hasProperty('ossrhPassword'))      ext.ossrhPassword       = System.getenv('SONATYPE_PASSWORD') ?: '**UNDEFINED**'
-if (!project.hasProperty('signingKeyId'))       ext.signingKeyId        = System.getenv('SIGNING_KEY_ID') ?: '**UNDEFINED**'
-if (!project.hasProperty('signingPassword'))    ext.signingPassword     = System.getenv('SIGNING_PASSWORD') ?: '**UNDEFINED**'
-if (!project.hasProperty('signingSecretKey'))   ext.signingSecretKey    = System.getenv('SIGNING_SECRET_KEY_PATH') ? rootProject.file(System.getenv('SIGNING_SECRET_KEY_PATH')).text : '**UNDEFINED**'
+if (!project.hasProperty('mavenCentralUsername'))       ext.mavenCentralUsername            = System.getenv('MAVEN_CENTRAL_USERNAME') ?: '**UNDEFINED**'
+if (!project.hasProperty('mavenCentralPassword'))       ext.mavenCentralPassword            = System.getenv('MAVEN_CENTRAL_PASSWORD') ?: '**UNDEFINED**'
+if (!project.hasProperty('signingInMemoryKeyId'))       ext.signingInMemoryKeyId            = System.getenv('SIGNING_KEY_ID') ?: '**UNDEFINED**'
+if (!project.hasProperty('signingInMemoryKeyPassword')) ext.signingInMemoryKeyPassword      = System.getenv('SIGNING_PASSWORD') ?: '**UNDEFINED**'
+if (!project.hasProperty('signingInMemoryKey'))         ext.signingInMemoryKey              = System.getenv('SIGNING_SECRET_KEY_PATH') ? rootProject.file(System.getenv('SIGNING_SECRET_KEY_PATH')).text : '**UNDEFINED**'
 
 config {
     release = (rootProject.findProperty('release') ?: false).toBoolean()
@@ -72,14 +71,18 @@ config {
     }
 
     publishing {
+        enabled = false
         signing {
-            enabled =  true
-            keyId = signingKeyId
-            secretKey = signingSecretKey
-            password = signingPassword
+            enabled = false
         }
         releasesRepository  = 'localRelease'
         snapshotsRepository = 'localSnapshot'
+    }
+
+    artifacts {
+        source {
+            enabled = false
+        }
     }
 
     quality {
@@ -115,17 +118,6 @@ config {
 
 }
 
-nexusPublishing {
-    repositories {
-        sonatype {
-            nexusUrl = uri("https://s01.oss.sonatype.org/service/local/")
-            snapshotRepositoryUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-            username = ossrhUsername
-            password = ossrhPassword
-        }
-    }
-}
-
 allprojects {
     repositories {
         mavenCentral()
@@ -147,41 +139,81 @@ allprojects {
     }
 }
 
-subprojects { subproject ->
-    if (subproject.name == 'guide') return
+gradleProjects {
+    subprojects {
+        dirs(['libs']) { Project subproject ->
+            if (subproject.name == 'guide') return
 
-    apply plugin: 'groovy'
+            apply plugin: 'groovy'
 
-    java {
-        toolchain {
-            languageVersion.set(JavaLanguageVersion.of(17))
+            java {
+                toolchain {
+                    languageVersion.set(JavaLanguageVersion.of(17))
+                }
+            }
+            // useful for Micronaut
+            tasks.withType(GroovyCompile) {
+                groovyOptions.forkOptions.jvmArgs.add('-Dgroovy.parameters=true')
+            }
+
+            // useful for Micronaut
+            tasks.withType(JavaCompile){
+                options.encoding = "UTF-8"
+                options.compilerArgs.add('-parameters')
+            }
+
+            // location independent tests (useful for stable CI builds)
+            tasks.withType(Test){
+                useJUnitPlatform()
+
+                systemProperty 'user.timezone', 'UTC'
+                systemProperty 'user.language', 'en'
+            }
+
+            // useful for IntelliJ
+            task cleanOut(type: Delete) {
+                delete file('out')
+            }
+
+            clean.dependsOn cleanOut
+
+            mavenPublishing {
+                publishToMavenCentral(true)
+                signAllPublications()
+
+                pom {
+                    name = "Micronaut Console"
+                    description = 'Micronaut Console'
+                    inceptionYear = "2020"
+                    url = "https://github.com/${slug}"
+                    licenses {
+                        license {
+                            name = "The Apache License, Version 2.0"
+                            url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+                            distribution = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+                        }
+                    }
+                    developers {
+                        developer {
+                            id = "musketyr"
+                            name = "Vladimir Orany"
+                            url = "https://github.com/musketyr/"
+                        }
+                    }
+                    scm {
+                        url = "https://github.com/${slug}.git"
+                        connection = "scm:git:git://github.com/${slug}.git"
+                        developerConnection = "scm:git:ssh://git@github.com/${slug}.git"
+                    }
+                }
+            }
+
+            signing {
+                useInMemoryPgpKeys(rootProject.ext.signingInMemoryKey, rootProject.ext.signingInMemoryKeyPassword)
+                sign publishing.publications
+            }
         }
     }
-    // useful for Micronaut
-    tasks.withType(GroovyCompile) {
-        groovyOptions.forkOptions.jvmArgs.add('-Dgroovy.parameters=true')
-    }
-
-    // useful for Micronaut
-    tasks.withType(JavaCompile){
-        options.encoding = "UTF-8"
-        options.compilerArgs.add('-parameters')
-    }
-
-    // location independent tests (useful for stable CI builds)
-    tasks.withType(Test){
-        useJUnitPlatform()
-
-        systemProperty 'user.timezone', 'UTC'
-        systemProperty 'user.language', 'en'
-    }
-
-    // useful for IntelliJ
-    task cleanOut(type: Delete) {
-        delete file('out')
-    }
-
-    clean.dependsOn cleanOut
 }
 
 check.dependsOn('aggregateCheckstyle', 'aggregateCodenarc', 'aggregateAllTestReports', 'coveralls')

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/groovy/micronaut-compatibility.gradle
+++ b/buildSrc/src/main/groovy/micronaut-compatibility.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/guide/guide.gradle
+++ b/docs/guide/guide.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/micronaut-console-example-application/gradle.properties
+++ b/examples/micronaut-console-example-application/gradle.properties
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright 2020-2024 Agorapulse.
+# Copyright 2020-2025 Agorapulse.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/micronaut-console-example-application/micronaut-console-example-application.gradle
+++ b/examples/micronaut-console-example-application/micronaut-console-example-application.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/micronaut-console-example-application/src/main/java/micronaut/console/example/Application.java
+++ b/examples/micronaut-console-example-application/src/main/java/micronaut/console/example/Application.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/micronaut-console-example-application/src/main/java/micronaut/console/example/AuthenticationProviderUserPassword.java
+++ b/examples/micronaut-console-example-application/src/main/java/micronaut/console/example/AuthenticationProviderUserPassword.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/micronaut-console-example-application/src/main/java/micronaut/console/example/SimpleAuthentication.java
+++ b/examples/micronaut-console-example-application/src/main/java/micronaut/console/example/SimpleAuthentication.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/micronaut-console-example-application/src/main/java/micronaut/console/example/SimpleAuthenticationResponse.java
+++ b/examples/micronaut-console-example-application/src/main/java/micronaut/console/example/SimpleAuthenticationResponse.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/micronaut-console-example-application/src/main/resources/logback.xml
+++ b/examples/micronaut-console-example-application/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
 
     SPDX-License-Identifier: Apache-2.0
 
-    Copyright 2020-2024 Agorapulse.
+    Copyright 2020-2025 Agorapulse.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/micronaut-console-example-application/src/test/groovy/micronaut/console/example/MicronautSecurityDisabledIntegrationSpec.groovy
+++ b/examples/micronaut-console-example-application/src/test/groovy/micronaut/console/example/MicronautSecurityDisabledIntegrationSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/micronaut-console-example-application/src/test/groovy/micronaut/console/example/MicronautSecurityIntegrationSpec.groovy
+++ b/examples/micronaut-console-example-application/src/test/groovy/micronaut/console/example/MicronautSecurityIntegrationSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/micronaut-console-example-application/src/test/resources/execute.sh
+++ b/examples/micronaut-console-example-application/src/test/resources/execute.sh
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright 2020-2024 Agorapulse.
+# Copyright 2020-2025 Agorapulse.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/micronaut-console-example-kotlin/micronaut-console-example-kotlin.gradle
+++ b/examples/micronaut-console-example-kotlin/micronaut-console-example-kotlin.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/micronaut-console-example-kotlin/src/main/kotlin/micronaut/console/example/kotlin/Application.kt
+++ b/examples/micronaut-console-example-kotlin/src/main/kotlin/micronaut/console/example/kotlin/Application.kt
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/micronaut-console-example-kotlin/src/main/resources/logback.xml
+++ b/examples/micronaut-console-example-kotlin/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
 
     SPDX-License-Identifier: Apache-2.0
 
-    Copyright 2020-2024 Agorapulse.
+    Copyright 2020-2025 Agorapulse.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright 2020-2024 Agorapulse.
+# Copyright 2020-2025 Agorapulse.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,9 +19,9 @@
 slug=agorapulse/micronaut-console
 group=com.agorapulse
 version=4.0.0-SNAPSHOT
-kordampPluginVersion=0.51.0
+kordampPluginVersion=0.53.0
 gitPublishPluginVersion=2.1.3
-nexusPluginVersion=1.0.0
+mavenCentralPublishPluginVersion=0.34.0
 
 micronautVersion = 4.2.0
 micronautGradlePluginVersion = 4.2.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/libs/micronaut-console/micronaut-console.gradle
+++ b/libs/micronaut-console/micronaut-console.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/AuditService.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/AuditService.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/BindingProvider.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/BindingProvider.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ConsoleConfiguration.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ConsoleConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ConsoleEngine.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ConsoleEngine.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ConsoleEngineFactory.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ConsoleEngineFactory.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ConsoleException.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ConsoleException.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ConsoleSecurityException.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ConsoleSecurityException.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ConsoleService.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ConsoleService.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/DefaultAuditService.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/DefaultAuditService.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/DefaultBindingProvider.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/DefaultBindingProvider.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/DefaultConsoleEngineFactory.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/DefaultConsoleEngineFactory.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/DefaultConsoleService.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/DefaultConsoleService.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ExecutionResult.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ExecutionResult.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/Script.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/Script.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/SecurityAdvisor.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/SecurityAdvisor.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/User.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/User.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/advisors/AddressAdvisor.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/advisors/AddressAdvisor.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/advisors/EnabledAdvisor.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/advisors/EnabledAdvisor.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/advisors/UntilAdvisor.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/advisors/UntilAdvisor.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/advisors/UsersAdvisor.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/advisors/UsersAdvisor.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/function/AuthConsoleHandler.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/function/AuthConsoleHandler.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/function/AuthorizedScript.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/function/AuthorizedScript.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/function/ConsoleHandler.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/function/ConsoleHandler.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/groovy/CompilerConfigurationCustomizer.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/groovy/CompilerConfigurationCustomizer.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/groovy/DsldGenerator.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/groovy/DsldGenerator.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/groovy/GdslGenerator.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/groovy/GdslGenerator.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/groovy/GroovyConsoleEngine.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/groovy/GroovyConsoleEngine.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/AnonymousUserArgumentBinder.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/AnonymousUserArgumentBinder.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/ConsoleController.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/ConsoleController.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/ConsoleHeadersFilter.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/ConsoleHeadersFilter.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/MicronautSecurityUserArgumentBinder.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/MicronautSecurityUserArgumentBinder.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/RequestBindingProvider.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/RequestBindingProvider.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/RequestHolder.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/RequestHolder.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/ScriptJsonError.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/ScriptJsonError.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ide/DslGenerator.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ide/DslGenerator.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ide/TextGenerator.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/ide/TextGenerator.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/jsr223/JavaScriptingConsoleEngine.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/jsr223/JavaScriptingConsoleEngine.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/jsr223/JavaScriptingConsoleEngineFactory.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/jsr223/JavaScriptingConsoleEngineFactory.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/util/ExceptionSanitizer.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/util/ExceptionSanitizer.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/BindingProviderSpec.groovy
+++ b/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/BindingProviderSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/UserTest.groovy
+++ b/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/UserTest.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/function/AuthConsoleHandlerSpec.groovy
+++ b/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/function/AuthConsoleHandlerSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/function/ConsoleHandlerSpec.groovy
+++ b/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/function/ConsoleHandlerSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/CloudSpec.groovy
+++ b/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/CloudSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/ConsoleControllerSpec.groovy
+++ b/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/ConsoleControllerSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/ConsoleHeadersFilterSpec.groovy
+++ b/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/ConsoleHeadersFilterSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/DefaultInterceptedInterface.groovy
+++ b/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/DefaultInterceptedInterface.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/DemoBindingProvider.groovy
+++ b/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/DemoBindingProvider.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/InterceptedInterface.groovy
+++ b/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/InterceptedInterface.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/MagicAdvisor.java
+++ b/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/MagicAdvisor.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/ParentClass.groovy
+++ b/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/ParentClass.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/SimpleUserBinder.java
+++ b/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/SimpleUserBinder.java
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/UntilSpec.groovy
+++ b/libs/micronaut-console/src/test/groovy/com/agorapulse/micronaut/console/http/UntilSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/resources/com/agorapulse/micronaut/console/http/ConsoleControllerSpec/jsr223.js
+++ b/libs/micronaut-console/src/test/resources/com/agorapulse/micronaut/console/http/ConsoleControllerSpec/jsr223.js
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-console/src/test/resources/log4j2.xml
+++ b/libs/micronaut-console/src/test/resources/log4j2.xml
@@ -3,7 +3,7 @@
 
     SPDX-License-Identifier: Apache-2.0
 
-    Copyright 2020-2024 Agorapulse.
+    Copyright 2020-2025 Agorapulse.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2020-2024 Agorapulse.
+ * Copyright 2020-2025 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/settings.gradle
+++ b/settings.gradle
@@ -28,17 +28,18 @@ pluginManagement {
         id 'org.kordamp.gradle.guide'               version kordampPluginVersion
         id 'org.kordamp.gradle.coveralls'           version kordampPluginVersion
         id 'org.ajoberstar.git-publish'             version gitPublishPluginVersion
-        id 'io.github.gradle-nexus.publish-plugin'  version nexusPluginVersion
     }
 }
 
 buildscript {
     repositories {
         mavenCentral()
+        gradlePluginPortal()
     }
 
     dependencies {
         classpath 'org.apache.httpcomponents:httpclient:4.5.5'
+        classpath "com.vanniktech:gradle-maven-publish-plugin:$mavenCentralPublishPluginVersion"
     }
 }
 
@@ -56,6 +57,12 @@ gradleEnterprise {
 
 projects {
     directories = ['libs', 'docs', 'examples']
+
+    plugins {
+        dir('libs') {
+            id 'com.vanniktech.maven.publish'
+        }
+    }
 }
 
 rootProject.name = 'micronaut-console-root'

--- a/settings.gradle
+++ b/settings.gradle
@@ -44,7 +44,6 @@ buildscript {
         classpath group: 'org.kordamp.gradle',      name: 'guide-gradle-plugin',            version: kordampPluginVersion
         classpath group: 'org.kordamp.gradle',      name: 'coveralls-gradle-plugin',        version: kordampPluginVersion
         classpath group: 'org.ajoberstar',          name: 'gradle-git-publish',             version: gitPublishPluginVersion
-        classpath group: 'io.github.gradle-nexus',  name: 'publish-plugin',                 version: nexusPluginVersion
         classpath group: 'io.micronaut.gradle',     name: 'micronaut-minimal-plugin',       version: micronautGradlePluginVersion
         classpath group: 'org.jetbrains.kotlin',    name: 'kotlin-gradle-plugin',           version: kotlinVersion
         classpath group: 'org.jetbrains.kotlin',    name: 'kotlin-allopen',                 version: kotlinVersion


### PR DESCRIPTION
- Update Kordamp plugin version from 0.51.0 to 0.53.0
- Replace Nexus publishing plugin with Vanniktech Maven Central plugin (0.34.0)
- Update signing configuration to use in-memory keys
- Change publishing credentials from OSSRH to Maven Central
- Update GitHub Actions workflows to use latest versions (v4)
- Replace publishToSonatype with publishAndReleaseToMavenCentral
- Add agorapulse-oss to notification matrix
- Update release versioning to use github.ref_name

This migration aligns with the publishing infrastructure used in sibling projects (micronaut-aws-sdk, micronaut-facebook-sdk, testing-libraries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)