### PR TITLE
Migrate from RxJava 2 to Project Reactor

### DIFF
--- a/docs/guide/src/docs/asciidoc/releases.adoc
+++ b/docs/guide/src/docs/asciidoc/releases.adoc
@@ -2,6 +2,12 @@
 [[_release_notes_]]
 = Release Notes
 
+== 4.0.0
+
+=== Breaking Changes
+
+* Dropped the `io.micronaut.rxjava2:micronaut-rxjava2` dependency in preparation for Micronaut Platform 5, which removes it from the BOM. The reactive filter `ConsoleHeadersFilter` has been rewritten on top of Project Reactor (`reactor.core.publisher.Mono`). The filter still returns `org.reactivestreams.Publisher`, so consumers that only interact with the published API through the reactive-streams contract are unaffected. Downstream projects that previously pulled RxJava 2 transitively through `micronaut-console` must now declare their own dependency on `io.micronaut.rxjava2:micronaut-rxjava2` (or migrate to Reactor / RxJava 3).
+
 == 3.0.0
 
 === Breaking Changes

--- a/examples/micronaut-console-example-application/micronaut-console-example-application.gradle
+++ b/examples/micronaut-console-example-application/micronaut-console-example-application.gradle
@@ -50,7 +50,7 @@ dependencies {
     implementation 'org.apache.groovy:groovy'
     implementation 'io.micronaut.security:micronaut-security'
     implementation 'io.micronaut.security:micronaut-security-jwt'
-    implementation 'io.micronaut.rxjava2:micronaut-rxjava2'
+    implementation 'io.micronaut.reactor:micronaut-reactor'
 
 
     implementation 'io.micronaut:micronaut-inject'

--- a/examples/micronaut-console-example-application/src/main/java/micronaut/console/example/AuthenticationProviderUserPassword.java
+++ b/examples/micronaut-console-example-application/src/main/java/micronaut/console/example/AuthenticationProviderUserPassword.java
@@ -23,9 +23,8 @@ import io.micronaut.security.authentication.AuthenticationFailed;
 import io.micronaut.security.authentication.AuthenticationProvider;
 import io.micronaut.security.authentication.AuthenticationRequest;
 import io.micronaut.security.authentication.AuthenticationResponse;
-import io.reactivex.BackpressureStrategy;
-import io.reactivex.Flowable;
 import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
 
 import jakarta.inject.Singleton;
 
@@ -34,14 +33,10 @@ public class AuthenticationProviderUserPassword implements AuthenticationProvide
 
     // @Override changed in Micronaut 2.x
     public Publisher<AuthenticationResponse> authenticate(AuthenticationRequest<?, ?> authenticationRequest) {
-        return Flowable.create(emitter -> {
-            if (authenticationRequest.getIdentity().equals("sherlock") && authenticationRequest.getSecret().equals("password")) {
-                emitter.onNext(new SimpleAuthenticationResponse(new SimpleAuthentication(authenticationRequest.getIdentity().toString())));
-                emitter.onComplete();
-            } else {
-                emitter.onError(new AuthenticationException(new AuthenticationFailed()));
-            }
-        }, BackpressureStrategy.ERROR);
+        if (authenticationRequest.getIdentity().equals("sherlock") && authenticationRequest.getSecret().equals("password")) {
+            return Mono.just(new SimpleAuthenticationResponse(new SimpleAuthentication(authenticationRequest.getIdentity().toString())));
+        }
+        return Mono.error(new AuthenticationException(new AuthenticationFailed()));
     }
 
     // @Override changed in Micronaut 2.x

--- a/libs/micronaut-console/micronaut-console.gradle
+++ b/libs/micronaut-console/micronaut-console.gradle
@@ -29,7 +29,7 @@ dependencies {
     compileOnly 'io.micronaut:micronaut-http'
     compileOnly 'io.micronaut:micronaut-function'
 
-    implementation 'io.micronaut.rxjava2:micronaut-rxjava2'
+    implementation 'io.micronaut.reactor:micronaut-reactor'
     implementation 'io.micronaut:micronaut-jackson-databind'
 
     testImplementation 'io.micronaut:micronaut-http-server-netty'

--- a/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/ConsoleHeadersFilter.java
+++ b/libs/micronaut-console/src/main/groovy/com/agorapulse/micronaut/console/http/ConsoleHeadersFilter.java
@@ -26,10 +26,10 @@ import io.micronaut.http.HttpStatus;
 import io.micronaut.http.annotation.Filter;
 import io.micronaut.http.filter.FilterChain;
 import io.micronaut.http.filter.HttpFilter;
-import io.reactivex.Flowable;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
 
 @Filter("${console.path:/console}/**")
 @Requires(property = "console.header-name")
@@ -49,21 +49,18 @@ public class ConsoleHeadersFilter implements HttpFilter {
 
     @Override
     public Publisher<? extends HttpResponse<?>> doFilter(HttpRequest<?> request, FilterChain chain) {
-        return Flowable.just(request)
-            .switchMap(req -> {
-                if (HttpMethod.POST.equals(req.getMethod())) {
-                    String headerValue = req.getHeaders().get(configuration.getHeaderName());
-                    if (headerValue == null) {
-                        return Flowable.just(HttpResponse.status(HttpStatus.FORBIDDEN, "Missing verification header"));
-                    }
+        if (HttpMethod.POST.equals(request.getMethod())) {
+            String headerValue = request.getHeaders().get(configuration.getHeaderName());
+            if (headerValue == null) {
+                return Mono.just(HttpResponse.status(HttpStatus.FORBIDDEN, "Missing verification header"));
+            }
 
-                    if (!headerValue.equals(configuration.getHeaderValue())) {
-                        return Flowable.just(HttpResponse.status(HttpStatus.FORBIDDEN, "Wrong value of the verification header"));
-                    }
-                }
+            if (!headerValue.equals(configuration.getHeaderValue())) {
+                return Mono.just(HttpResponse.status(HttpStatus.FORBIDDEN, "Wrong value of the verification header"));
+            }
+        }
 
-                return chain.proceed(req);
-            });
+        return chain.proceed(request);
     }
 
 }


### PR DESCRIPTION
## Summary
This PR migrates the micronaut-console library from RxJava 2 to Project Reactor in preparation for Micronaut Platform 5, which removes RxJava 2 from the BOM.

## Key Changes
- **ConsoleHeadersFilter**: Refactored reactive implementation from `Flowable` to `Mono`
  - Replaced `Flowable.just()` and `switchMap()` with direct conditional logic
  - Simplified the filter logic by removing unnecessary reactive wrapping for synchronous operations
  - Maintained the `Publisher<? extends HttpResponse<?>>` return type for API compatibility

- **AuthenticationProviderUserPassword**: Simplified authentication logic using `Mono`
  - Replaced `Flowable.create()` with `BackpressureStrategy.ERROR` with direct `Mono.just()` and `Mono.error()` calls
  - Removed unnecessary emitter-based callback pattern for straightforward success/error paths

- **Dependencies**: Updated build configurations
  - Changed from `io.micronaut.rxjava2:micronaut-rxjava2` to `io.micronaut.reactor:micronaut-reactor`
  - Applied to both library and example application

- **Documentation**: Added release notes for version 4.0.0 documenting the breaking change

## Implementation Details
The refactored code maintains backward compatibility at the API level since both implementations return `org.reactivestreams.Publisher`. The changes simplify the code by using Project Reactor's more intuitive API for simple success/error scenarios, eliminating the need for complex reactive operators when the logic is inherently synchronous.

https://claude.ai/code/session_01VKpJVSz4WDJVZvWqJbiCY3