### PR TITLE
fix(guide): drop asciidoctorj-tabbed-code-extension to unblock Gradle 9.5

### DIFF
--- a/docs/guide/guide.gradle
+++ b/docs/guide/guide.gradle
@@ -27,17 +27,7 @@ gitPublish {
     password = providers.environmentVariable('GIT_PUBLISH_PASSWORD').orElse('')
 }
 
-configurations {
-    asciidoctorExtensions
-}
-
-dependencies {
-    asciidoctorExtensions 'com.bmuschko:asciidoctorj-tabbed-code-extension:0.3'
-}
-
 asciidoctor {
-    configurations 'asciidoctorExtensions'
-
     baseDirFollowsSourceDir()
 
     attributes = [


### PR DESCRIPTION
## Summary

The Release workflow has been failing at `:guide:asciidoctor` since the Gradle 9.5 / Mn5 baseline landed:

```
ClassCastException: UnionFileCollection cannot be cast to Configuration
Could not determine the dependencies of task ':guide:asciidoctor'.
```

The Check workflow doesn't run `:guide:asciidoctor`, so it stayed green and the regression slipped through. Build scan from the broken 5.0.0.RC1 release: https://scans.gradle.com/s/hs6z6tuqlomui/failures

## Fix

Drop the local `asciidoctorExtensions` configuration + `com.bmuschko:asciidoctorj-tabbed-code-extension:0.3` dep. The extension is **already on the `:guide` asciidoctor classpath transitively** via the Agorapulse `com.agorapulse.gradle.guide` plugin and auto-registers through asciidoctorj's SPI — the local wiring was a redundant double-registration, and that's exactly what trips the cast on Gradle 9.5.

## No visual regression

Tabs continue to work because the extension is still loaded transitively. Verified by rendering `:guide:asciidoctor` locally after the drop:

* generated `index.html` still contains the tab JS (`addBlockSwitches`, `switch--item`) and styles
* `<div class="listingblock primary">` / `secondary` survive as before
* visual check (headless Chrome screenshot) confirms the tabbed Bash blocks render normally

Same approach gru 3.0.0.RC2 already shipped successfully — gru's released docs at https://agorapulse.github.io/gru/ still have working tabs.

## Test plan
- [x] `./gradlew :guide:asciidoctor` succeeds locally
- [x] generated HTML still contains tab JS/CSS
- [x] visual confirmation (screenshot)
- [ ] CI green on this PR
- [ ] Re-tag a release (the previous 5.0.0.RC1 tag exists but the publish never completed)
